### PR TITLE
Adds `CompileWarning` if .env file found

### DIFF
--- a/waspc/cli/src/Wasp/Cli/Command/Deps.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Deps.hs
@@ -5,6 +5,7 @@ where
 
 import Control.Monad.Except (throwError)
 import Control.Monad.IO.Class (liftIO)
+import Data.List.NonEmpty (toList)
 import Wasp.AppSpec (AppSpec)
 import qualified Wasp.AppSpec.App.Dependency as AS.Dependency
 import Wasp.Cli.Command (Command, CommandError (..))
@@ -20,10 +21,10 @@ import qualified Wasp.Util.Terminal as Term
 deps :: Command ()
 deps = do
   waspProjectDir <- findWaspProjectRootDirFromCwd
-  appSpecOrCompileErrors <- liftIO $ analyzeWaspProject waspProjectDir (defaultCompileOptions waspProjectDir)
+  (_, appSpecOrCompileErrors) <- liftIO $ analyzeWaspProject waspProjectDir (defaultCompileOptions waspProjectDir)
   appSpec <-
     either
-      (throwError . CommandError "Determining dependencies failed due to a compilation error in your Wasp project" . unwords)
+      (throwError . CommandError "Determining dependencies failed due to a compilation error in your Wasp project" . unwords . toList)
       return
       appSpecOrCompileErrors
 

--- a/waspc/cli/src/Wasp/Cli/Command/Deps.hs
+++ b/waspc/cli/src/Wasp/Cli/Command/Deps.hs
@@ -21,12 +21,12 @@ import qualified Wasp.Util.Terminal as Term
 deps :: Command ()
 deps = do
   waspProjectDir <- findWaspProjectRootDirFromCwd
-  (_, appSpecOrCompileErrors) <- liftIO $ analyzeWaspProject waspProjectDir (defaultCompileOptions waspProjectDir)
+  (_, appSpecOrAnalyzerErrors) <- liftIO $ analyzeWaspProject waspProjectDir (defaultCompileOptions waspProjectDir)
   appSpec <-
     either
       (throwError . CommandError "Determining dependencies failed due to a compilation error in your Wasp project" . unwords . toList)
       return
-      appSpecOrCompileErrors
+      appSpecOrAnalyzerErrors
 
   liftIO . putStrLn $ depsMessage appSpec
 

--- a/waspc/src/Wasp/Lib.hs
+++ b/waspc/src/Wasp/Lib.hs
@@ -38,7 +38,6 @@ compile ::
   IO ([CompileWarning], [CompileError])
 compile waspDir outDir options = do
   (compileWarnings, appSpecOrCompileErrors) <- analyzeWaspProject waspDir options
-  print compileWarnings
   case appSpecOrCompileErrors of
     Left compileErrors -> return (compileWarnings, toList compileErrors)
     Right appSpec ->

--- a/waspc/src/Wasp/Lib.hs
+++ b/waspc/src/Wasp/Lib.hs
@@ -85,7 +85,7 @@ analyzeWaspProject waspDir options = do
                   AS.isBuild = CompileOptions.isBuild options
                 }
 
--- | Checks the wasp directory for potential problems, and issues a warning if any are found.
+-- | Checks the wasp directory for potential problems, and issues warnings if any are found.
 analyzeWaspDir :: Path' Abs (Dir WaspProjectDir) -> IO [GeneratorWarning]
 analyzeWaspDir waspDir = do
   maybeDotEnvFile <- findDotEnv waspDir

--- a/waspc/src/Wasp/Lib.hs
+++ b/waspc/src/Wasp/Lib.hs
@@ -44,8 +44,7 @@ compile waspDir outDir options = do
       case ASV.validateAppSpec appSpec of
         [] -> do
           (generatorWarnings, generatorErrors) <- Generator.writeWebAppCode appSpec outDir (sendMessage options)
-          let filteredGeneratorWarnings = generatorWarningsFilter options generatorWarnings
-          return (map show filteredGeneratorWarnings, map show generatorErrors)
+          return (map show $ generatorWarningsFilter options generatorWarnings, map show generatorErrors)
         validationErrors -> do
           return ([], map show validationErrors)
   return $ (analyzerWarnings, []) <> compilerWarningsAndErrors

--- a/waspc/src/Wasp/Lib.hs
+++ b/waspc/src/Wasp/Lib.hs
@@ -8,6 +8,7 @@ module Wasp.Lib
 where
 
 import Data.List (find, isSuffixOf)
+import Data.List.NonEmpty (NonEmpty, fromList, toList)
 import StrongPath (Abs, Dir, File', Path', relfile)
 import qualified StrongPath as SP
 import System.Directory (doesDirectoryExist, doesFileExist)
@@ -22,7 +23,6 @@ import Wasp.Error (showCompilerErrorForTerminal)
 import qualified Wasp.ExternalCode as ExternalCode
 import qualified Wasp.Generator as Generator
 import Wasp.Generator.Common (ProjectRootDir)
-import Wasp.Generator.Monad (GeneratorWarning (GenericGeneratorWarning))
 import Wasp.Generator.ServerGenerator.Common (dotEnvServer)
 import Wasp.Generator.WebAppGenerator.Common (dotEnvClient)
 import qualified Wasp.Util.IO as Util.IO
@@ -37,61 +37,68 @@ compile ::
   CompileOptions ->
   IO ([CompileWarning], [CompileError])
 compile waspDir outDir options = do
-  appSpecOrCompileErrors <- analyzeWaspProject waspDir options
+  (compileWarnings, appSpecOrCompileErrors) <- analyzeWaspProject waspDir options
+  print compileWarnings
   case appSpecOrCompileErrors of
-    Left compileErrors -> return ([], compileErrors)
+    Left compileErrors -> return (compileWarnings, toList compileErrors)
     Right appSpec ->
       case ASV.validateAppSpec appSpec of
         [] -> do
           (generatorWarnings, generatorErrors) <- Generator.writeWebAppCode appSpec outDir (sendMessage options)
-          allWarnings <- (generatorWarnings ++) <$> analyzeWaspDir waspDir
-          return (map show $ generatorWarningsFilter options allWarnings, map show generatorErrors)
+          let filteredGeneratorWarnings = map show $ generatorWarningsFilter options generatorWarnings
+          return (filteredGeneratorWarnings ++ compileWarnings, map show generatorErrors)
         validationErrors -> do
-          return ([], map show validationErrors)
+          return (compileWarnings, map show validationErrors)
 
 analyzeWaspProject ::
   Path' Abs (Dir WaspProjectDir) ->
   CompileOptions ->
-  IO (Either [CompileError] AS.AppSpec)
+  IO ([CompileWarning], Either (NonEmpty CompileError) AS.AppSpec)
 analyzeWaspProject waspDir options = do
+  warnings <- warnIfDotEnvPresent waspDir
   maybeWaspFilePath <- findWaspFile waspDir
   case maybeWaspFilePath of
-    Nothing -> return $ Left ["Couldn't find a single *.wasp file."]
+    Nothing -> return (warnings, Left $ fromList ["Couldn't find a single *.wasp file."])
     Just waspFilePath -> do
       waspFileContent <- readFile (SP.fromAbsFile waspFilePath)
       case Analyzer.analyze waspFileContent of
         Left analyzeError ->
-          return $
-            Left
-              [ showCompilerErrorForTerminal
-                  (waspFilePath, waspFileContent)
-                  (getErrorMessageAndCtx analyzeError)
-              ]
+          return
+            ( warnings,
+              Left $
+                fromList
+                  [ showCompilerErrorForTerminal
+                      (waspFilePath, waspFileContent)
+                      (getErrorMessageAndCtx analyzeError)
+                  ]
+            )
         Right decls -> do
           externalCodeFiles <-
             ExternalCode.readFiles (CompileOptions.externalCodeDirPath options)
           maybeDotEnvServerFile <- findDotEnvServer waspDir
           maybeDotEnvClientFile <- findDotEnvClient waspDir
           maybeMigrationsDir <- findMigrationsDir waspDir
-          return $
-            Right
-              AS.AppSpec
-                { AS.decls = decls,
-                  AS.externalCodeFiles = externalCodeFiles,
-                  AS.externalCodeDirPath = CompileOptions.externalCodeDirPath options,
-                  AS.migrationsDir = maybeMigrationsDir,
-                  AS.dotEnvServerFile = maybeDotEnvServerFile,
-                  AS.dotEnvClientFile = maybeDotEnvClientFile,
-                  AS.isBuild = CompileOptions.isBuild options
-                }
+          return
+            ( warnings,
+              Right
+                AS.AppSpec
+                  { AS.decls = decls,
+                    AS.externalCodeFiles = externalCodeFiles,
+                    AS.externalCodeDirPath = CompileOptions.externalCodeDirPath options,
+                    AS.migrationsDir = maybeMigrationsDir,
+                    AS.dotEnvServerFile = maybeDotEnvServerFile,
+                    AS.dotEnvClientFile = maybeDotEnvClientFile,
+                    AS.isBuild = CompileOptions.isBuild options
+                  }
+            )
 
 -- | Checks the wasp directory for potential problems, and issues warnings if any are found.
-analyzeWaspDir :: Path' Abs (Dir WaspProjectDir) -> IO [GeneratorWarning]
-analyzeWaspDir waspDir = do
+warnIfDotEnvPresent :: Path' Abs (Dir WaspProjectDir) -> IO [CompileWarning]
+warnIfDotEnvPresent waspDir = do
   maybeDotEnvFile <- findDotEnv waspDir
   case maybeDotEnvFile of
     Nothing -> return []
-    Just _ -> return [GenericGeneratorWarning "Wasp .env files should be named .env.server or .env.client, depending on their use."]
+    Just _ -> return ["Wasp .env files should be named .env.server or .env.client, depending on their use."]
 
 findWaspFile :: Path' Abs (Dir WaspProjectDir) -> IO (Maybe (Path' Abs File'))
 findWaspFile waspDir = do


### PR DESCRIPTION
# Description

Normally, we'd return `GeneratorWarning`s from the `Generator` itself. However, since we need access to `WaspProjectDir` I was thinking this is probably a decent enough spot for it to go. We can return a `CompileWarning` instead directly.